### PR TITLE
Update: Translate German text to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AKZ Währungsrechner</title>
+    <title>AKZ Currency Converter</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -129,61 +129,61 @@
 </head>
 <body>
     <div class="container">
-        <h1>AKZ Währungsrechner</h1>
+        <h1>AKZ Currency Converter</h1>
         <div class="converter">
             <div class="rate-type-selector">
-                <label>Kurstyp:</label>
+                <label>Rate Type:</label>
                 <select id="rateType" onchange="updateConversion()">
-                    <option value="official">Offizieller Kurs</option>
-                    <option value="kinguila">Kinguila (Straßenkurs)</option>
+                    <option value="official">Official Rate</option>
+                    <option value="kinguila">Kinguila (Street Rate)</option>
                 </select>
             </div>
             <div class="input-group">
-                <input type="number" id="amount" placeholder="Betrag eingeben" onchange="updateConversion()">
+                <input type="number" id="amount" placeholder="Enter amount" onchange="updateConversion()">
                 <select id="fromCurrency" onchange="updateConversion()">
                     <option value="AKZ">AKZ</option>
                     <option value="EUR">EUR</option>
                     <option value="USD">USD</option>
                 </select>
-                <span>zu</span>
+                <span>to</span>
                 <select id="toCurrency" onchange="updateConversion()">
                     <option value="EUR">EUR</option>
                     <option value="USD">USD</option>
                     <option value="AKZ">AKZ</option>
                 </select>
-                <button onclick="convert()">Umrechnen</button>
+                <button onclick="convert()">Convert</button>
             </div>
             <div class="result" id="result">
-                Ergebnis wird hier angezeigt
+                Result will be displayed here
             </div>
             <div class="rates" id="rates">
                 <table class="rates-table">
                     <thead>
                         <tr>
-                            <th>Währung</th>
-                            <th>Offizieller Kurs</th>
-                            <th>Kinguila Kurs</th>
+                            <th>Currency</th>
+                            <th>Official Rate</th>
+                            <th>Kinguila Rate</th>
                         </tr>
                     </thead>
                     <tbody id="ratesBody">
                         <tr>
                             <td>EUR/AKZ</td>
-                            <td>Wird geladen...</td>
-                            <td>Wird geladen...</td>
+                            <td>Loading...</td>
+                            <td>Loading...</td>
                         </tr>
                         <tr>
                             <td>USD/AKZ</td>
-                            <td>Wird geladen...</td>
-                            <td>Wird geladen...</td>
+                            <td>Loading...</td>
+                            <td>Loading...</td>
                         </tr>
                     </tbody>
                 </table>
             </div>
             <div class="update-time" id="updateTime"></div>
-            <div class="loading" id="loading">Aktualisiere Wechselkurse...</div>
-            <button onclick="updateRates()" class="update-button">Wechselkurse aktualisieren</button>
+            <div class="loading" id="loading">Updating exchange rates...</div>
+            <button onclick="updateRates()" class="update-button">Update Exchange Rates</button>
             <div class="source-link">
-                <p>Quelle: <a href="https://angocambio.ao/home" target="_blank">Angocâmbio</a></p>
+                <p>Source: <a href="https://angocambio.ao/home" target="_blank">Angocâmbio</a></p>
             </div>
         </div>
     </div>
@@ -232,19 +232,19 @@
                 const response = await fetch('https://angocambio.ao/home');
                 if (response.ok) {
                     const data = await response.text();
-                    // Hier müsste der HTML-Parser für angocambio.ao implementiert werden
-                    // Da wir keinen direkten API-Zugriff haben, behalten wir vorerst die Beispielwerte
+                    // HTML parser for angocambio.ao would be implemented here
+                    // For now, we keep the example values since we don't have direct API access
                     
-                    // Aktualisiere das Datum
+                    // Update the date
                     const now = new Date();
                     document.getElementById('updateTime').innerHTML = 
-                        `Letzte Aktualisierung: ${now.toLocaleString('de-DE')}`;
+                        `Last Update: ${now.toLocaleString('en-US')}`;
                     
-                    // Aktualisiere die Anzeige der Wechselkurse
+                    // Update the exchange rates display
                     updateRatesDisplay();
                 }
             } catch (error) {
-                console.error('Fehler beim Aktualisieren der Wechselkurse:', error);
+                console.error('Error updating exchange rates:', error);
             }
             document.getElementById('loading').style.display = 'none';
         }
@@ -272,18 +272,18 @@
             const rateType = document.getElementById('rateType').value;
             
             if (isNaN(amount)) {
-                document.getElementById('result').innerHTML = 'Bitte geben Sie einen gültigen Betrag ein';
+                document.getElementById('result').innerHTML = 'Please enter a valid amount';
                 return;
             }
 
             const result = amount * rates[rateType][fromCurrency][toCurrency];
-            const formattedResult = new Intl.NumberFormat('de-DE', {
+            const formattedResult = new Intl.NumberFormat('en-US', {
                 maximumFractionDigits: 2,
                 minimumFractionDigits: 2
             }).format(result);
 
             document.getElementById('result').innerHTML = 
-                `${amount} ${fromCurrency} = ${formattedResult} ${toCurrency} (${rateType === 'official' ? 'Offizieller Kurs' : 'Kinguila Kurs'})`;
+                `${amount} ${fromCurrency} = ${formattedResult} ${toCurrency} (${rateType === 'official' ? 'Official Rate' : 'Kinguila Rate'})`;
         }
 
         function updateConversion() {
@@ -293,7 +293,7 @@
             }
         }
 
-        // Initialisierung
+        // Initialization
         window.onload = function() {
             updateRates();
             updateRatesDisplay();


### PR DESCRIPTION
This PR translates all German text in the currency converter to English, making it more accessible to English-speaking users.

Changes made:
- Changed document language from "de" to "en"
- Updated page title from "AKZ Währungsrechner" to "AKZ Currency Converter"
- Translated all UI elements (labels, buttons, messages) to English
- Updated locale formatting from 'de-DE' to 'en-US' for numbers and dates
- Improved error messages and system notifications
- Maintained all existing functionality

These changes improve accessibility while preserving all original features and functionality.